### PR TITLE
2 fixes for validation false-positives

### DIFF
--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -53,22 +53,31 @@ export class Validator {
         });
     }
 
-    public validateSchema(filename: string): Promise<Error[]> {
+    public validateSchema(filename: string, parameters: any = {}): Promise<Error[]> {
         return new Promise((resolve, reject) => {
-            console.log(`Validatin schema for ${filename}`);
+            console.log(`Validating schema for ${filename}`);
             var errorFile = this.validateJson(filename);
             if (errorFile) reject(errorFile);
             let current: any = JSON.parse(fs.readFileSync(filename).toString());
-            this.substitueDefaults(current);
+
+            if ('parameters' in current) {
+                for (var parameter in parameters) {
+                    if (parameters.hasOwnProperty(parameter)) {
+                        Object.assign(current.parameters[parameter], parameters[parameter]);
+                    }
+                }
+            }
+
+            this.substituteDefaults(current);
             this.validator.validate(current["$schema"], current);
             resolve(this.validator.errors || []);
         });
     }
 
-    private substitueDefaults(template: any) {
+    private substituteDefaults(template: any) {
         var parameters = (value: string): any => {
             if (value in template.parameters) {
-                return template.parameters[value].defaultValue;
+                return template.parameters[value].value || template.parameters[value].defaultValue || "";
             }
         };
         var variables = (value: string): any => {

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -32,7 +32,7 @@ export class Validator {
             CurrentSchemas.forEach(schema => {
                 requests.push(axios.get(schema));
             });
-            Promise.all(requests)
+            return Promise.all(requests)
                 .then(results => {
                     results.forEach(result => {
                         //HACK: until microsoft fix their base schemas.

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -107,6 +107,12 @@ export class Validator {
         }
         if (template.resources) {
             template.resources.forEach((resource: any, i) => {
+
+                // Avoids schema failures due to validation of [resourceGroup.location()] against the valid location enum
+                function resourceGroup() {
+                    return { location: 'West US' };
+                }
+
                 Object.keys(resource)
                     .forEach((resourceKey: string) => {
                         if (typeof template.resources[i][resourceKey] === 'string' && template.resources[i][resourceKey].startsWith(`[`)) {

--- a/test/validator.quickstart.test.ts
+++ b/test/validator.quickstart.test.ts
@@ -33,23 +33,40 @@ class ValidatorQuickStart {
                     this._files.forEach(file => {
                         let fileName = file.split('\\')[file.split('\\').length - 1];
                         let fileParent = file.split('\\')[file.split('\\').length - 2];
+                        let paramFile = file.split('.json')[0] + '.parameters.json';
+                        let paramExists = fs.existsSync(paramFile);
+
                         it(`${fileParent}\\${fileName}`, (done) => {
+                            if (paramExists) {
+                                var error = this._validator.validateJson(paramFile);
+                                if (error) {
+                                    done(error);
+                                }
+                            }
+
                             var error = this._validator.validateJson(file);
                             if (error) {
                                 done(error);
                             }
                             else {
-                                this._validator.validateSchema(file)
-                                    .then(errors => {
-                                        if (errors.length > 0) {
-                                            done(errors[0]);
-                                        } else {
-                                            expect(errors).to.be.empty;
-                                            done();
-                                        }
+                                var errors;
+                                if (paramExists) {
+                                    let paramSchema: any = JSON.parse(fs.readFileSync(paramFile).toString());
+                                    errors = this._validator.validateSchema(file, paramSchema.parameters);
+                                }
+                                else {
+                                    errors = this._validator.validateSchema(file);
+                                }
+                                errors.then(errors => {
+                                    if (errors.length > 0) {
+                                        done(errors[0]);
+                                    } else {
+                                        expect(errors).to.be.empty;
+                                        done();
+                                    }
 
-                                    })
-                                    .catch(err => done(err));
+                                })
+                                .catch(err => done(err));
                             };
                         });
 

--- a/test/validator.quickstart.test.ts
+++ b/test/validator.quickstart.test.ts
@@ -26,7 +26,7 @@ class ValidatorQuickStart {
 
     }
     public RunTest() {
-        this._validator.Initialize()
+        return this._validator.Initialize()
             .then(() => {
                 describe("Validate files", () => {
 
@@ -60,6 +60,12 @@ class ValidatorQuickStart {
     }
 
 }
-var quickStart = new ValidatorQuickStart();
-quickStart.RunTest();
 
+// See http://stackoverflow.com/a/35793665
+var quickStart = new ValidatorQuickStart();
+before(function() {
+    return quickStart.RunTest();
+});
+it('Placeholder to allow before() to work', function () {
+    console.log('Mocha requires this in order to block for async generation of tests');
+});

--- a/test/validator.schema.test.ts
+++ b/test/validator.schema.test.ts
@@ -14,7 +14,8 @@ describe('Validate Schemas', () => {
         .catch((err: any) => done(err));
     })
     it('BasicValidation', (done) => {
-        _self.validator.validateSchema('./test/baseFiles/validTemplate.json')
+        let paramSchema: any = JSON.parse('./test/baseFiles/validParam.json');
+        _self.validator.validateSchema('./test/baseFiles/validTemplate.json', paramSchema.parameters)
         .then((result: Error[]) => {
             if(result) expect(result).to.be.empty;
             done();


### PR DESCRIPTION
Thanks for open-sourcing this - I had to make minor bugfixes to reduce false positives against the quickstart repo:
- Substitutes [resourceGroup().location] to 'West US' to avoid validation errors
- Avoid validation error due to lack of default value for parameters
- Wait for async mocha test case generation to finish